### PR TITLE
Added a photo to events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,13 +4,40 @@ class Event < ApplicationRecord
   has_many :bottles
   has_many :guests, through: :bookings, class_name: "User" # Rajout Lucie
 
-  has_one_attached :photo
-
-  CATEGORIES = %w[alsace beaujolais bordeaux bourgogne champagne corse jura lanquedoc loire provence rhone sud]
+  CATEGORIES = %w[Alsace-Lorraine Beaujolais Bordeaux Bourgogne Champagne Corse Jura-Bugey-Savoie Languedoc-Roussillon Loire Provence Rhône Sud-Ouest]
 
   # Validations
-  # validates :name, :address, :date, :level, presence: true
+  validates :name, :address, :date, :level, presence: true
   validates :level, inclusion: { in: %w[Novice Intermédiaire Expert] }
   validates :category, inclusion: { in: CATEGORIES }
 
+  after_create do
+    case category
+    when CATEGORIES[0]
+      self.photo = "alsace.jpg"
+    when CATEGORIES[1]
+      self.photo = "beaujolais.jpg"
+    when CATEGORIES[2]
+      self.photo = "bordeaux.jpg"
+    when CATEGORIES[3]
+      self.photo = "bourgogne.jpg"
+    when CATEGORIES[4]
+      self.photo = "champagne.jpg"
+    when CATEGORIES[5]
+      self.photo = "corse.jpg"
+    when CATEGORIES[6]
+      self.photo = "jura.jpg"
+    when CATEGORIES[7]
+      self.photo = "languedoc.jpg"
+    when CATEGORIES[8]
+      self.photo = "loire.jpg"
+    when CATEGORIES[9]
+      self.photo = "provence.jpg"
+    when CATEGORIES[10]
+      self.photo = "rhone.jpg"
+    when CATEGORIES[11]
+      self.photo = "sud.jpg"
+    end
+    self.save
+  end
 end

--- a/app/views/dashboards/dashboard.html.erb
+++ b/app/views/dashboards/dashboard.html.erb
@@ -31,7 +31,7 @@
 <%# Display future events (host) %>
 <% @future_hosted_events.each do |event| %>
   <div class="card-dashboard-2">
-    <%= cl_image_tag event.photo.key %>
+      <%= image_tag "#{event.photo}" %>
     <div class="card-dashboard-2-infos">
       <div class= "d-flex justify-content-between">
         <h3><%= event.date.strftime('%d %b %Y') %> - <%= event.time.strftime('%H:%M') %></h3>
@@ -50,7 +50,7 @@
 <%# Display future bookings (guest) %>
 <% @future_attended_events.each do |event| %>
  <div class="card-dashboard-2">
-    <%= cl_image_tag event.photo.key %>
+      <%= image_tag "#{event.photo}" %>
     <div class="card-dashboard-2-infos">
       <div class= "d-flex justify-content-between">
         <h3><%= event.date.strftime('%d %b %Y') %> - <%= event.time.strftime('%H:%M') %></h3>
@@ -73,7 +73,7 @@
 <%# Display past events (host) %>
 <% @past_hosted_events.each do |event| %>
   <div class="card-dashboard-2">
-    <%= cl_image_tag event.photo.key %>
+      <%= image_tag "#{event.photo}" %>
     <div class="card-dashboard-2-infos">
       <div class= "d-flex justify-content-between">
 
@@ -87,7 +87,7 @@
 <%# Display past bookings (guest) %>
 <% @past_attended_events.each do |event| %>
  <div class="card-dashboard-2">
-    <%= cl_image_tag event.photo.key %>
+      <%= image_tag "#{event.photo}" %>
     <div class="card-dashboard-2-infos">
       <div class= "d-flex justify-content-between">
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -5,8 +5,7 @@
     <div class="unique-card">
       <%= link_to event_path(event) do %>
       <div class="card-image-index">
-
-        <%= image_tag "#{event.category}.jpg" %>
+        <%= image_tag "#{event.photo}" %>
       </div>
 
       <% end %>
@@ -15,7 +14,7 @@
       <div class="card-text-index">
 
         <p class="text-date-index"><%= event.date %></p>
-        <p class="text-date-index"><%= t(event.category) %></p>
+        <p class="text-date-index"><%= event.category%></p>
 
         <p class="text-name-event-index"><%= event.name.capitalize %></p>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,7 @@
     <div class="card-beg">
 
       <div class="photo-card">
-        <%= image_tag "#{@event.category}.jpg" %>
+        <%= image_tag "#{@event.photo}" %>
         <div class="avatar-show">
           <ul>
             <%= @event.host.first_name %>

--- a/config/locales/fr/event.fr.yml
+++ b/config/locales/fr/event.fr.yml
@@ -6,7 +6,7 @@ fr:
   champagne: Champagne
   corse: Corse
   jura: Jura Bugey Savoie
-  lanquedoc: Languedoc-Roussillon
+  languedoc: Languedoc-Roussillon
   loire: Loire
   provence: Provence
   rhone: Rhône

--- a/db/migrate/20220902202859_add_photo_to_events.rb
+++ b/db/migrate/20220902202859_add_photo_to_events.rb
@@ -1,0 +1,5 @@
+class AddPhotoToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :photo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_02_105038) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_02_202859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_105038) do
     t.string "city"
     t.string "postal_code"
     t.string "region"
+    t.string "photo"
     t.index ["host_id"], name: "index_events_on_host_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,13 +64,28 @@ user3.save
 
 puts "Creating events..."
 
+loire_test = Event.create!(
+  name: 'test',
+  description: "test",
+  address: "test",
+  date: Date.parse('3rd Feb 2022'),
+  time: Time.parse('08:30'),
+  category: 'Loire',
+  level: 'Novice',
+  host_request: 'test',
+  max_number_guest: 12,
+  min_price: 8,
+  max_price: 12,
+  host: user1
+)
+
 loire = Event.create!(
   name: 'descente de la loire en pinard',
   description: "Je vous invite dans mon jardin, sous le pont de cheviré pour une descente de la loire par ses pinards : du côte roannaise en Auvergne jusqu'à notre Muscadet local",
   address: "49 quai Émile Cormerais, 44800 Saint-Herblain",
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: "loire",
+  category: 'Loire',
   level: 'Novice',
   host_request: '1 côte-roannaise et 1 muscadet-sèvre-et-maine',
   max_number_guest: 12,
@@ -79,9 +94,7 @@ loire = Event.create!(
   host: user1
 )
 
-file = URI.open("https://cap.img.pmdstatic.net/fit/http.3A.2F.2Fprd2-bone-image.2Es3-website-eu-west-1.2Eamazonaws.2Ecom.2Fcap.2F2019.2F08.2F04.2Fa843fc6f-5f7c-43e3-aec0-89f62c93a745.2Ejpeg/1200x630/background-color/ffffff/quality/70/dormez-comme-un-roi-et-sauvez-le-chateau-de-chambord-1346662.jpg")
-loire.photo.attach(io: file, filename: "loire.png", content_type: "image/png")
-loire.save
+
 
 
 champagne = Event.create!(
@@ -90,7 +103,7 @@ champagne = Event.create!(
   address:'49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Nov 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -99,9 +112,7 @@ champagne = Event.create!(
   host: user1
 )
 
-file = URI.open("https://cdn.aveine.paris/blog/wp-content/uploads/2021/06/09141104/Tour-de-France-regions-viticoles-Cave-Champagne.jpg")
-champagne.photo.attach(io: file, filename: "champagne.png", content_type: "image/png")
-champagne.save
+
 
 alsace_lorraine = Event.create!(
   name: "retour de route des vins alsaciens",
@@ -109,7 +120,7 @@ alsace_lorraine = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Nov 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -117,9 +128,7 @@ alsace_lorraine = Event.create!(
   max_price: 12,
   host: user3
 )
-file = URI.open("https://cdn.aveine.paris/blog/wp-content/uploads/2021/06/09142030/Tour-de-France-regions-viticoles-Route-des-vins-Alsace.jpg")
-alsace_lorraine.photo.attach(io: file, filename: "alsace-lorraine.png", content_type: "image/png")
-alsace_lorraine.save
+
 
 bourgogne = Event.create!(
   name: 'nuit blanche au côte de nuits',
@@ -127,7 +136,7 @@ bourgogne = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Nov 2022'),
   time: Time.parse('17:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -135,9 +144,7 @@ bourgogne = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://cdn.aveine.paris/blog/wp-content/uploads/2021/06/09142442/Tour-de-France-regions-viticoles-Hospices-de-Beaune.jpg")
-bourgogne.photo.attach(io: file, filename: "bourgogne.png", content_type: "image/png")
-bourgogne.save
+
 
 jura_savoie_bugey = Event.create!(
   name: 'dégustation des vins de nos montagnes',
@@ -145,7 +152,7 @@ jura_savoie_bugey = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Nov 2022'),
   time: Time.parse('17:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -153,9 +160,7 @@ jura_savoie_bugey = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://img.lemde.fr/2022/04/20/0/0/5433/3578/664/0/75/0/19246b4_1650467126993-pns-900571516.jpg")
-jura_savoie_bugey.photo.attach(io: file, filename: "jura_savoie_bugey.png", content_type: "image/png")
-jura_savoie_bugey.save
+
 
 beaujolais = Event.create!(
   name: 'soirée beaujolais pas nouveau',
@@ -163,7 +168,7 @@ beaujolais = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Nov 2022'),
   time: Time.parse('17:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -171,9 +176,7 @@ beaujolais = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://www.lavoixdelain.fr/photos/moyen/39703.jpg")
-beaujolais.photo.attach(io: file, filename: "beaujolais.png", content_type: "image/png")
-beaujolais.save
+
 
 vallee_du_rhone = Event.create!(
   name: 'vallée du rhône méridonale et charcuterie',
@@ -181,7 +184,7 @@ vallee_du_rhone = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('17:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -189,9 +192,7 @@ vallee_du_rhone = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://cdn.aveine.paris/blog/wp-content/uploads/2021/06/09142144/Tour-de-France-regions-viticoles-Palais-des-Papes.jpg")
-vallee_du_rhone.photo.attach(io: file, filename: "valee_du_rhone.png", content_type: "image/png")
-vallee_du_rhone.save
+
 
 corse = Event.create!(
   name: 'vins corsés et fromages qui puent',
@@ -199,7 +200,7 @@ corse = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -207,9 +208,7 @@ corse = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://www.allibert-trekking.com/uploads/media/images/thumbnails/AMin3_2027-balisage-gr20.jpeg?v5")
-corse.photo.attach(io: file, filename: "corse.png", content_type: "image/png")
-corse.save
+
 
 provence = Event.create!(
   name: 'pic-nique arrosé aux vins de provence',
@@ -217,7 +216,7 @@ provence = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -225,9 +224,7 @@ provence = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://media.istockphoto.com/photos/lavender-in-provence-at-sunrise-picture-id1133997327?k=20&m=1133997327&s=612x612&w=0&h=B5sIQ-f2gCvvZPpk1FW_uIwGnn_nF79bK9yIDl6M0aw=")
-provence.photo.attach(io: file, filename: "provence.png", content_type: "image/png")
-provence.save
+
 
 languedoc_roussillon = Event.create!(
   name: 'dégustation de nos vins du Roussillon',
@@ -235,7 +232,7 @@ languedoc_roussillon = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -243,9 +240,7 @@ languedoc_roussillon = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://cdn.generationvoyage.fr/2020/11/couverture-pont-du-gard.jpg")
-languedoc_roussillon.photo.attach(io: file, filename: "languedoc_roussillon.png", content_type: "image/png")
-languedoc_roussillon.save
+
 
 sud_ouest = Event.create!(
   name: 'garden party et vins de notre pays basque',
@@ -253,7 +248,7 @@ sud_ouest = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Novice',
   host_request: '',
   max_number_guest: '',
@@ -261,9 +256,7 @@ sud_ouest = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://media.istockphoto.com/photos/red-espelette-peppers-drying-in-the-wall-of-basque-house-picture-id502807780?k=20&m=502807780&s=612x612&w=0&h=XJtkTZelu_9ntRznhitoupIJ61KaYCfj604wcKen8Sc=")
-sud_ouest.photo.attach(io: file, filename: "sud_ouest.png", content_type: "image/png")
-sud_ouest.save
+
 
 bordeaux = Event.create!(
   name: "dégustation premium d'entre-deux-mers",
@@ -271,7 +264,7 @@ bordeaux = Event.create!(
   address: '49 quai Émile Cormerais, 44800 Saint-Herblain',
   date: Date.parse('3rd Feb 2022'),
   time: Time.parse('08:30'),
-  category: :loire,
+  category: 'Loire',
   level: 'Expert',
   host_request: '',
   max_number_guest: '',
@@ -279,9 +272,7 @@ bordeaux = Event.create!(
   max_price: 12,
   host: user1
 )
-file = URI.open("https://static-otelico.com/cache/seekoo/0-La-Cite-du-Vin-reflets-1---Axelferis-7.jpg")
-bordeaux.photo.attach(io: file, filename: "bordeaux.png", content_type: "image/png")
-bordeaux.save
+
 
 puts "Creating bottles..."
 


### PR DESCRIPTION
- Ajout d'une colonne "photo" à la table "events"
- Dans les seeds : on ne met pas de photo pour les événements (que ce soit via Cloudinary ou autre)
- La photo d'un événement sera appelée via ce code dans les views :         <%= image_tag "#{@event.photo}" %>
- J'ai modifié l'index, la show et le dashboard (seules pages où on trouve des photos d'événements a priori)